### PR TITLE
fix `docker container run --network-alias`

### DIFF
--- a/python_on_whales/components/container/cli_wrapper.py
+++ b/python_on_whales/components/container/cli_wrapper.py
@@ -644,7 +644,7 @@ class ContainerCLI(DockerCLICaller):
         full_cmd.add_simple_arg("--name", name)
 
         full_cmd.add_args_list("--network", networks)
-        full_cmd.add_args_list("--network-aliases", network_aliases)
+        full_cmd.add_args_list("--network-alias", network_aliases)
 
         full_cmd.add_flag("--oom-kill-disable", not oom_kill)
         full_cmd.add_simple_arg("--oom-score-adj", oom_score_adj)


### PR DESCRIPTION
```
$ docker version
Client:
 Cloud integration: 1.0.17
 Version:           20.10.8
 API version:       1.41
 Go version:        go1.16.6
 Git commit:        3967b7d
 Built:             Fri Jul 30 19:58:50 2021
 OS/Arch:           windows/amd64
 Context:           default
 Experimental:      true

$ docker container run --help | grep network
      --network network                Connect a container to a network
      --network-alias list             Add network-scoped alias for the
```